### PR TITLE
Headless LVGL UI simulator with auto-generated README demo (+ Phase 2 WASM plan)

### DIFF
--- a/.github/workflows/ui-demo.yml
+++ b/.github/workflows/ui-demo.yml
@@ -1,0 +1,89 @@
+#
+# ui-demo.yml — Build the LVGL UI on a host runner, capture a deterministic
+# animation of a scripted tour, and publish it for the README.
+#
+# On pull requests it builds + encodes and uploads the result as an artifact so
+# you can preview the UI before merging (and it doubles as a build gate). On
+# pushes to main it additionally publishes the animation to the orphan `media`
+# branch, which the README references by raw URL — so main's history never
+# accumulates regenerated binaries.
+#
+name: UI Demo
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "ui/**"
+      - "sim/**"
+      - ".github/workflows/ui-demo.yml"
+  pull_request:
+    paths:
+      - "ui/**"
+      - "sim/**"
+      - ".github/workflows/ui-demo.yml"
+  workflow_dispatch:
+
+# Needed so the publish step can push to the `media` branch.
+permissions:
+  contents: write
+
+concurrency:
+  group: ui-demo-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  render:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake build-essential ffmpeg
+
+      - name: Build simulator
+        run: |
+          cmake -S sim -B sim/build -DCMAKE_BUILD_TYPE=Release
+          cmake --build sim/build -j"$(nproc)"
+
+      - name: Capture frames
+        run: |
+          mkdir -p frames
+          ./sim/build/ipod_ui_sim frames
+
+      - name: Encode animation
+        run: |
+          ./sim/encode.sh frames out
+
+      - name: Upload preview artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ui-demo
+          path: |
+            out/ui-demo.webp
+            out/ui-demo.gif
+            out/ui-poster.png
+          if-no-files-found: error
+
+      - name: Publish to media branch
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # Stage the freshly-encoded assets outside the work tree.
+          staging="$(mktemp -d)"
+          cp out/ui-demo.webp out/ui-demo.gif out/ui-poster.png "$staging/"
+
+          # Rebuild `media` as a single orphan commit each time so the repo
+          # never accumulates old binary blobs.
+          git checkout --orphan media-publish
+          git rm -rf . >/dev/null 2>&1 || true
+          cp "$staging"/* .
+          echo "Auto-generated UI demo assets. Do not edit by hand." > README.md
+          git add ui-demo.webp ui-demo.gif ui-poster.png README.md
+          git commit -m "Update UI demo [skip ci]"
+          git push -f origin media-publish:media

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# Simulator build + capture output
+sim/build/
+frames/
+out/
+*.webp
+*.gif

--- a/README.md
+++ b/README.md
@@ -59,3 +59,9 @@ the event table in `sim/tour.c`.
 
 The ESP32 firmware is built with the Arduino CLI (see
 `.github/workflows/main.yml`).
+
+### Roadmap: live interactive demo
+
+A future phase compiles the same `ui/` code to WebAssembly for a clickable,
+in-browser version of the UI hosted on GitHub Pages. The implementation plan
+lives in [`docs/phase2-wasm-live-demo-plan.md`](docs/phase2-wasm-live-demo-plan.md).

--- a/README.md
+++ b/README.md
@@ -1,2 +1,61 @@
 # esp32_ipod_classic
+
 A revitalization using an iPod Video (5th gen) based off of the ESP-32 MCU
+
+## UI Preview
+
+The animation below is generated automatically from the actual LVGL UI code on
+every merge to `main` that touches the UI — no device required. It renders a
+scripted "tour" of the interface headlessly in CI. See
+[Development → UI simulator](#ui-simulator) for how it works.
+
+![iPod UI demo](https://raw.githubusercontent.com/EvanClements/esp32_ipod_classic/media/ui-demo.webp)
+
+<!-- If the WebP above doesn't animate in your viewer, the GIF fallback lives at
+     .../media/ui-demo.gif on the same branch. -->
+
+## Development
+
+### UI simulator
+
+The UI is written in **LVGL** and kept strictly hardware-independent (see
+`ui/`), so the exact same code runs on the ESP32 and on a plain Linux host.
+That lets CI build the UI and record how it looks and behaves without any
+hardware in the loop.
+
+```
+ui/                 Hardware-independent LVGL UI (shared by device + sim)
+  ui.h / ui.c       Screens, navigation, and the ui_send_key() input seam
+sim/                Host-only capture harness
+  main.c            Headless LVGL display -> framebuffer -> PNG per frame
+  tour.c / tour.h   The scripted demo (a table of {frame, key} events)
+  frame_png.*       Tiny dependency-free PNG writer (no libpng/zlib needed)
+  lv_conf.h         LVGL config for the host build
+  encode.sh         Frames -> animated WebP + GIF (uses ffmpeg)
+  CMakeLists.txt    Fetches LVGL and builds `ipod_ui_sim`
+```
+
+Build and run it locally:
+
+```bash
+cmake -S sim -B sim/build -DCMAKE_BUILD_TYPE=Release
+cmake --build sim/build -j
+./sim/build/ipod_ui_sim frames        # writes frames/frame_0000.png ...
+./sim/encode.sh frames out            # writes out/ui-demo.webp and .gif
+```
+
+**Why it's reproducible:** the harness drives LVGL's clock by a fixed step per
+frame instead of screen-recording in real time, so the captured animation
+(including LVGL's easing and progress animations) is byte-for-byte identical on
+every machine and never drops frames under CI load. The same PNG frames can
+later back visual-regression tests.
+
+The clickwheel maps to four logical inputs — `PREV`, `NEXT`, `SELECT`, `MENU` —
+fed through `ui_send_key()`. On the device the clickwheel driver calls it; in
+the simulator the scripted tour calls it. To change what the demo shows, edit
+the event table in `sim/tour.c`.
+
+### Firmware build
+
+The ESP32 firmware is built with the Arduino CLI (see
+`.github/workflows/main.yml`).

--- a/docs/phase2-wasm-live-demo-plan.md
+++ b/docs/phase2-wasm-live-demo-plan.md
@@ -1,0 +1,253 @@
+# Phase 2 — WASM Live Interactive UI Demo (Plan)
+
+> Status: **planned, not yet implemented.** This document is the implementation
+> guide for adding a live, clickable web version of the iPod UI on top of the
+> Phase 1 headless capture pipeline.
+
+## Goal
+
+Let anyone **play with the real UI in their browser** — scroll the wheel, open
+menus, watch Now Playing — with no device and no local build. The same
+`ui/ui.c` that runs on the ESP32 and in the headless simulator is compiled to
+WebAssembly and rendered to an HTML5 canvas, hosted on GitHub Pages.
+
+This is additive. Phase 1 (the auto-generated README animation) stays exactly
+as-is and remains the thing embedded in the README; Phase 2 adds a **"▶ Try it
+live" link** next to it.
+
+## Why this is cheap to build now
+
+Phase 1 already did the hard architectural work:
+
+- `ui/ui.c` / `ui/ui.h` are **hardware-independent LVGL** with a single input
+  seam, `ui_send_key(ui_key_t)`. Nothing in there needs to change.
+- We already know the LVGL version (v9.2.2), the config surface (`lv_conf.h`),
+  and the CMake/FetchContent setup.
+
+Phase 2 is a **third build target** for the same UI code: device (Arduino),
+native headless (`sim/`), and now web (`web/`). The UI is the constant; only the
+display driver, input source, and main loop differ per target.
+
+```
+                 ui/ui.c  (shared, hardware-independent)
+                    |
+      +-------------+-------------------+
+      |             |                   |
+   ESP32 fw     sim/ (native,        web/ (emscripten,
+  (Arduino)     headless PNG)        SDL->canvas, live)   <-- Phase 2
+```
+
+## Architecture
+
+Add a `web/` directory that mirrors `sim/` but targets the browser:
+
+```
+web/
+  main.c            LVGL + SDL display, browser main loop, input export
+  lv_conf.h         Web-tuned LVGL config (SDL on, size-optimised)
+  shell.html        Page shell: canvas + iPod chrome + on-screen clickwheel
+  clickwheel.js     Pointer/drag on the wheel -> exported ui_send_key()
+  CMakeLists.txt    Emscripten build (or a build.sh calling emcc)
+```
+
+### Display driver
+
+LVGL v9 ships an SDL backend (`LV_USE_SDL`). Under Emscripten, SDL2 is provided
+by `-sUSE_SDL=2` and renders to a `<canvas>` via WebGL — so we get a real
+display driver with no extra driver code:
+
+```c
+lv_display_t *disp = lv_sdl_window_create(UI_W, UI_H);
+lv_sdl_mouse_create();      /* pointer -> LVGL (optional, for direct taps) */
+lv_sdl_keyboard_create();   /* keyboard -> LVGL group (optional)           */
+```
+
+### Main loop
+
+The browser cannot block, so replace `sim/`'s `for` loop with Emscripten's
+callback-driven loop (request-animation-frame paced):
+
+```c
+static void tick(void *arg) {
+    lv_tick_inc(16);          /* ~60 fps; wall-clock time is fine here —   */
+    lv_timer_handler();       /* determinism is only needed for capture     */
+}
+int main(void) {
+    lv_init();
+    /* create display + input as above */
+    ui_init();
+    emscripten_set_main_loop_arg(tick, NULL, 0 /*use rAF*/, 1);
+    return 0;
+}
+```
+
+Note the contrast with Phase 1: the headless harness drives a *fixed* timestep
+for byte-identical capture; the live demo just needs to feel smooth, so
+real-time ticking is correct here.
+
+### Input: the on-screen clickwheel
+
+The signature UX piece. The canvas shows only the screen; the iPod's wheel is
+drawn in HTML/SVG around it. `clickwheel.js` translates gestures into the same
+four logical inputs the firmware uses:
+
+- **Drag around the ring** → accumulate angle; every N degrees emit
+  `UI_KEY_NEXT` (clockwise) or `UI_KEY_PREV` (counter-clockwise).
+- **Center button click** → `UI_KEY_SELECT`.
+- **"MENU" region tap** → `UI_KEY_MENU`.
+- Keyboard fallback: arrow keys / Enter / Backspace map to the same four.
+
+Expose the seam to JS from C:
+
+```c
+#include <emscripten.h>
+EMSCRIPTEN_KEEPALIVE void web_send_key(int k) { ui_send_key((ui_key_t)k); }
+```
+
+```js
+// clickwheel.js
+const sendKey = Module.cwrap('web_send_key', null, ['number']);
+// PREV=0, NEXT=1, SELECT=2, MENU=3  (must match ui_key_t order)
+```
+
+Keep the `ui_key_t` enum order the single source of truth; document the numeric
+mapping in `clickwheel.js` right next to `cwrap`.
+
+## Build
+
+Two viable routes — pick one:
+
+1. **CMake + Emscripten toolchain** (preferred, matches `sim/`): reuse the same
+   FetchContent LVGL declaration; configure with
+   `emcmake cmake -S web -B web/build` and build with `cmake --build`. Link
+   flags via `target_link_options`.
+2. **Thin `build.sh` calling `emcc`** directly: simpler to read, but duplicates
+   the LVGL source list. Only choose this if the CMake+emscripten integration
+   fights us.
+
+Key `emcc`/link flags:
+
+```
+-sUSE_SDL=2
+-sALLOW_MEMORY_GROWTH=1
+-sEXPORTED_RUNTIME_METHODS=cwrap,ccall
+-sEXPORTED_FUNCTIONS=_main,_web_send_key
+--shell-file web/shell.html
+-Os                        # size matters for a web payload
+-o web-dist/index.html
+```
+
+### Payload size
+
+LVGL + ThorVG can produce a large `.wasm`. Mitigations, in the web `lv_conf.h`:
+
+- Disable ThorVG / vector graphics if unused (`LV_USE_THORVG_INTERNAL 0`,
+  `LV_USE_VECTOR_GRAPHIC 0`).
+- Enable only the fonts and widgets the UI actually uses.
+- Build `-Os` and enable `-sINITIAL_MEMORY` sizing after measuring.
+- Target: keep the gzipped payload comfortably under a few hundred KB. Measure
+  early; treat >1 MB gzipped as a signal to trim features.
+
+## Hosting & CI
+
+New workflow `.github/workflows/ui-live.yml`:
+
+```yaml
+on:
+  push:
+    branches: [main]
+    paths: ["ui/**", "web/**", ".github/workflows/ui-live.yml"]
+  workflow_dispatch:
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+jobs:
+  build-deploy:
+    runs-on: ubuntu-latest
+    environment: github-pages
+    steps:
+      - uses: actions/checkout@v4
+      - uses: mymindstorm/setup-emsdk@v14
+      - run: emcmake cmake -S web -B web/build && cmake --build web/build -j
+      - uses: actions/upload-pages-artifact@v3
+        with: { path: web-dist }
+      - uses: actions/deploy-pages@v4
+```
+
+**Prerequisite:** enable GitHub Pages for the repo (Settings → Pages → Source:
+GitHub Actions). Live URL will be:
+`https://evanclements.github.io/esp32_ipod_classic/`.
+
+Then in `README.md`, add a link beside the Phase 1 animation:
+
+```markdown
+[![iPod UI demo](https://.../media/ui-demo.webp)](https://evanclements.github.io/esp32_ipod_classic/)
+
+▶ **[Try the UI live in your browser](https://evanclements.github.io/esp32_ipod_classic/)** — no device needed.
+```
+
+## Testing
+
+A lightweight smoke test is enough (the live demo is interactive, so pixel
+determinism is out of scope):
+
+- **Local/CI smoke test with Playwright** (Chromium is already available in this
+  environment): serve `web-dist/` over http, load the page, wait for the canvas
+  to have non-zero size and the module to signal ready, dispatch a few key
+  events, and screenshot. Fail if the module doesn't boot or the canvas stays
+  blank. Run it as a CI gate on PRs that touch `web/**` or `ui/**`.
+- Manual cross-browser pass (Chrome, Firefox, Safari, mobile Safari) for the
+  clickwheel gesture feel — hard to automate, worth doing once.
+
+## Milestones
+
+Land these as separate, reviewable PRs:
+
+1. **Boot to canvas.** Emscripten build of the existing UI, keyboard input only,
+   run locally via `emrun`. Proves the toolchain and that `ui/` compiles for
+   web unmodified. *(Highest-risk step — do it first.)*
+2. **iPod chrome + clickwheel.** `shell.html` styling and `clickwheel.js`
+   gesture → `web_send_key` mapping. This is the actual "live demo" UX.
+3. **Pages deploy.** `ui-live.yml`, enable Pages, wire the README link.
+4. **Polish.** Responsive/HiDPI canvas sizing, loading indicator, touch support,
+   payload-size trim pass.
+5. **(Optional) Playwright smoke test** as a CI gate.
+6. **(Optional) Idle auto-play.** When untouched for a few seconds, replay the
+   `sim/tour.c` script so the page is never static — reuses the Phase 1 tour
+   data.
+
+## Risks & mitigations
+
+| Risk | Mitigation |
+| --- | --- |
+| CMake + Emscripten integration friction with FetchContent'd LVGL | Fall back to a `build.sh` that invokes `emcc` over an explicit source list |
+| WASM payload too large | Trim LVGL features in web `lv_conf.h`, `-Os`, measure gzip early |
+| Canvas sizing / HiDPI blurriness | Set canvas backing size = CSS size × `devicePixelRatio`; test on retina |
+| GitHub Pages not enabled | One-time repo setting; document it in the milestone-3 PR |
+| SDL/emscripten main-loop pitfalls (blocking) | Use `emscripten_set_main_loop_arg`; never call a blocking loop |
+| Clickwheel gesture feels wrong on touch vs mouse | Prototype in milestone 2; tune angle-per-tick threshold |
+
+## Effort estimate
+
+Roughly **1–2 focused days**: milestone 1 is a few hours once emscripten is set
+up; milestones 2–3 are the bulk; polish is open-ended but optional.
+
+## Open decisions
+
+- **Clickwheel interaction model:** continuous drag-to-rotate vs. tap-arc
+  zones. Recommendation: drag-to-rotate (most iPod-authentic), with keyboard as
+  the accessible fallback.
+- **Idle auto-play (milestone 6):** nice touch, but adds a JS↔C driver. Decide
+  after the core demo is up.
+- **Payload budget:** set a concrete gzipped-size ceiling once milestone 1
+  produces the first `.wasm` to measure against.
+
+## Definition of done
+
+- `web/` builds to `web-dist/` via a single documented command.
+- The page loads on GitHub Pages and the UI is fully navigable by wheel/keys.
+- README links to the live demo next to the animation.
+- CI rebuilds and redeploys on `main` changes to `ui/**` or `web/**`.
+- No changes were required to `ui/` — confirming the shared-UI architecture
+  held across all three targets.

--- a/sim/CMakeLists.txt
+++ b/sim/CMakeLists.txt
@@ -1,0 +1,35 @@
+cmake_minimum_required(VERSION 3.16)
+project(ipod_ui_sim C)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+
+include(FetchContent)
+
+# Point LVGL at our headless configuration and skip its examples/demos so the
+# build stays small and fast.
+set(LV_CONF_PATH ${CMAKE_CURRENT_SOURCE_DIR}/lv_conf.h CACHE STRING "" FORCE)
+set(LV_CONF_BUILD_DISABLE_EXAMPLES ON CACHE BOOL "" FORCE)
+set(LV_CONF_BUILD_DISABLE_DEMOS ON CACHE BOOL "" FORCE)
+
+FetchContent_Declare(
+  lvgl
+  GIT_REPOSITORY https://github.com/lvgl/lvgl.git
+  GIT_TAG v9.2.2
+  GIT_SHALLOW TRUE
+)
+FetchContent_MakeAvailable(lvgl)
+
+add_executable(ipod_ui_sim
+  main.c
+  frame_png.c
+  tour.c
+  ${CMAKE_CURRENT_SOURCE_DIR}/../ui/ui.c
+)
+
+target_include_directories(ipod_ui_sim PRIVATE
+  ${CMAKE_CURRENT_SOURCE_DIR}
+  ${CMAKE_CURRENT_SOURCE_DIR}/../ui
+)
+
+target_link_libraries(ipod_ui_sim PRIVATE lvgl)

--- a/sim/encode.sh
+++ b/sim/encode.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+#
+# encode.sh — turn a directory of frame_%04d.png captures into the demo assets.
+#
+# Produces an animated WebP (primary, referenced by the README) and an animated
+# GIF (fallback for anything that doesn't render WebP). Requires ffmpeg.
+#
+# Usage: encode.sh <frames_dir> <out_dir> [fps]
+set -euo pipefail
+
+FRAMES="${1:?usage: encode.sh <frames_dir> <out_dir> [fps]}"
+OUT="${2:?usage: encode.sh <frames_dir> <out_dir> [fps]}"
+FPS="${3:-30}"
+
+mkdir -p "$OUT"
+
+echo ">> Encoding animated WebP..."
+ffmpeg -y -hide_banner -loglevel error \
+  -framerate "$FPS" -i "$FRAMES/frame_%04d.png" \
+  -c:v libwebp -lossless 0 -quality 80 -preset drawing \
+  -loop 0 -an -fps_mode passthrough \
+  "$OUT/ui-demo.webp"
+
+echo ">> Encoding animated GIF (fallback)..."
+PAL="$(mktemp --suffix=.png)"
+ffmpeg -y -hide_banner -loglevel error \
+  -framerate "$FPS" -i "$FRAMES/frame_%04d.png" \
+  -vf "fps=$FPS,palettegen=stats_mode=diff" "$PAL"
+ffmpeg -y -hide_banner -loglevel error \
+  -framerate "$FPS" -i "$FRAMES/frame_%04d.png" -i "$PAL" \
+  -lavfi "fps=$FPS,paletteuse=dither=bayer:bayer_scale=3" \
+  -loop 0 "$OUT/ui-demo.gif"
+rm -f "$PAL"
+
+# A still poster (first frame) for embeds that want a static image.
+cp "$FRAMES/frame_0000.png" "$OUT/ui-poster.png"
+
+echo ">> Done:"
+ls -lh "$OUT"/ui-demo.webp "$OUT"/ui-demo.gif "$OUT"/ui-poster.png

--- a/sim/frame_png.c
+++ b/sim/frame_png.c
@@ -1,0 +1,128 @@
+#include "frame_png.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* ---- CRC32 (PNG chunks) -------------------------------------------------- */
+static uint32_t crc32_update(uint32_t crc, const uint8_t *buf, size_t len)
+{
+    static uint32_t table[256];
+    static int have_table = 0;
+    if (!have_table) {
+        for (uint32_t n = 0; n < 256; n++) {
+            uint32_t c = n;
+            for (int k = 0; k < 8; k++)
+                c = (c & 1) ? 0xedb88320u ^ (c >> 1) : (c >> 1);
+            table[n] = c;
+        }
+        have_table = 1;
+    }
+    crc ^= 0xffffffffu;
+    for (size_t i = 0; i < len; i++)
+        crc = table[(crc ^ buf[i]) & 0xff] ^ (crc >> 8);
+    return crc ^ 0xffffffffu;
+}
+
+/* ---- Adler32 (zlib) ------------------------------------------------------ */
+static uint32_t adler32(const uint8_t *data, size_t len)
+{
+    uint32_t a = 1, b = 0;
+    for (size_t i = 0; i < len; i++) {
+        a = (a + data[i]) % 65521u;
+        b = (b + a) % 65521u;
+    }
+    return (b << 16) | a;
+}
+
+/* ---- little writer helpers ----------------------------------------------- */
+static void put_be32(FILE *f, uint32_t v)
+{
+    uint8_t b[4] = { (uint8_t)(v >> 24), (uint8_t)(v >> 16),
+                     (uint8_t)(v >> 8),  (uint8_t)v };
+    fwrite(b, 1, 4, f);
+}
+
+static void write_chunk(FILE *f, const char *type, const uint8_t *data, size_t len)
+{
+    put_be32(f, (uint32_t)len);
+    fwrite(type, 1, 4, f);
+    if (len) fwrite(data, 1, len, f);
+
+    /* CRC is over the type + data as one run; crc32_update xors in/out per
+     * call, so compute it over a single concatenated buffer. */
+    uint8_t *tmp = (uint8_t *)malloc(4 + len);
+    memcpy(tmp, type, 4);
+    if (len) memcpy(tmp + 4, data, len);
+    uint32_t crc = crc32_update(0, tmp, 4 + len);
+    free(tmp);
+    put_be32(f, crc);
+}
+
+int frame_png_write(const char *path, const uint8_t *rgb, int width, int height)
+{
+    FILE *f = fopen(path, "wb");
+    if (!f) return 1;
+
+    static const uint8_t sig[8] = { 137, 80, 78, 71, 13, 10, 26, 10 };
+    fwrite(sig, 1, 8, f);
+
+    /* IHDR */
+    uint8_t ihdr[13];
+    ihdr[0] = (uint8_t)(width >> 24);  ihdr[1] = (uint8_t)(width >> 16);
+    ihdr[2] = (uint8_t)(width >> 8);   ihdr[3] = (uint8_t)width;
+    ihdr[4] = (uint8_t)(height >> 24); ihdr[5] = (uint8_t)(height >> 16);
+    ihdr[6] = (uint8_t)(height >> 8);  ihdr[7] = (uint8_t)height;
+    ihdr[8]  = 8;   /* bit depth   */
+    ihdr[9]  = 2;   /* colour type: truecolour RGB */
+    ihdr[10] = 0;   /* compression */
+    ihdr[11] = 0;   /* filter      */
+    ihdr[12] = 0;   /* interlace   */
+    write_chunk(f, "IHDR", ihdr, sizeof(ihdr));
+
+    /* Raw filtered image: each row prefixed with filter byte 0 (None). */
+    size_t row_bytes = (size_t)width * 3;
+    size_t raw_len   = (row_bytes + 1) * (size_t)height;
+    uint8_t *raw = (uint8_t *)malloc(raw_len);
+    if (!raw) { fclose(f); return 2; }
+    for (int y = 0; y < height; y++) {
+        uint8_t *dst = raw + (size_t)y * (row_bytes + 1);
+        *dst++ = 0;
+        memcpy(dst, rgb + (size_t)y * row_bytes, row_bytes);
+    }
+
+    /* zlib stream: 2-byte header + stored deflate blocks + adler32. */
+    size_t max_zlen = 2 + raw_len + 5 * (raw_len / 65535 + 1) + 4;
+    uint8_t *z = (uint8_t *)malloc(max_zlen);
+    if (!z) { free(raw); fclose(f); return 3; }
+    size_t zp = 0;
+    z[zp++] = 0x78;   /* CMF */
+    z[zp++] = 0x01;   /* FLG (no dict, fastest) */
+
+    size_t off = 0;
+    while (off < raw_len) {
+        size_t block = raw_len - off;
+        if (block > 65535) block = 65535;
+        uint8_t bfinal = (off + block >= raw_len) ? 1 : 0;
+        z[zp++] = bfinal;                       /* stored block, BTYPE=00 */
+        z[zp++] = (uint8_t)(block & 0xff);
+        z[zp++] = (uint8_t)((block >> 8) & 0xff);
+        uint16_t nlen = (uint16_t)~block;
+        z[zp++] = (uint8_t)(nlen & 0xff);
+        z[zp++] = (uint8_t)((nlen >> 8) & 0xff);
+        memcpy(z + zp, raw + off, block);
+        zp += block;
+        off += block;
+    }
+    uint32_t ad = adler32(raw, raw_len);
+    z[zp++] = (uint8_t)(ad >> 24); z[zp++] = (uint8_t)(ad >> 16);
+    z[zp++] = (uint8_t)(ad >> 8);  z[zp++] = (uint8_t)ad;
+
+    write_chunk(f, "IDAT", z, zp);
+    write_chunk(f, "IEND", NULL, 0);
+
+    free(z);
+    free(raw);
+    fclose(f);
+    return 0;
+}

--- a/sim/frame_png.h
+++ b/sim/frame_png.h
@@ -1,0 +1,17 @@
+/*
+ * frame_png.h — Minimal, dependency-free PNG writer.
+ *
+ * Writes 8-bit RGB PNGs using stored (uncompressed) zlib blocks, so it needs
+ * neither libpng nor zlib. Good enough for capturing simulator frames that
+ * ffmpeg then encodes into the animated demo.
+ */
+#ifndef FRAME_PNG_H
+#define FRAME_PNG_H
+
+#include <stdint.h>
+
+/* rgb points at width*height*3 bytes, row-major, R,G,B order.
+ * Returns 0 on success, non-zero on failure. */
+int frame_png_write(const char *path, const uint8_t *rgb, int width, int height);
+
+#endif /* FRAME_PNG_H */

--- a/sim/lv_conf.h
+++ b/sim/lv_conf.h
@@ -1,0 +1,26 @@
+/*
+ * lv_conf.h — LVGL configuration for the headless simulator build.
+ *
+ * Only the settings that differ from LVGL's defaults are listed; everything
+ * else falls through to lv_conf_internal.h. The device build will have its
+ * own lv_conf.h tuned for the ESP32 (PSRAM, display driver, etc.).
+ */
+#ifndef LV_CONF_H
+#define LV_CONF_H
+
+/* 32-bit colour so we can dump clean RGB frames for the recorder. */
+#define LV_COLOR_DEPTH 32
+
+/* Plenty of heap for a desktop build. */
+#define LV_MEM_SIZE (256 * 1024U)
+
+/* Fonts used by the UI. */
+#define LV_FONT_MONTSERRAT_14 1
+#define LV_FONT_MONTSERRAT_16 1
+#define LV_FONT_MONTSERRAT_22 1
+#define LV_FONT_DEFAULT &lv_font_montserrat_14
+
+/* lv_snapshot is handy for still-frame regression tests later. */
+#define LV_USE_SNAPSHOT 1
+
+#endif /* LV_CONF_H */

--- a/sim/main.c
+++ b/sim/main.c
@@ -1,0 +1,82 @@
+/*
+ * main.c — Headless LVGL capture harness.
+ *
+ * Boots LVGL with an in-memory display (no SDL, no X server, no GPU), builds
+ * the shared UI, then plays the scripted tour at a FIXED timestep — advancing
+ * LVGL's clock by a constant amount per frame and snapshotting the framebuffer
+ * to a PNG. Because time is driven manually, the captured animation is
+ * identical on every machine, so the demo never flickers or drops frames the
+ * way a real-time screen recording on a shared CI runner would.
+ *
+ * Usage: ipod_ui_sim [output_dir]   (default: ./frames)
+ */
+#include "lvgl.h"
+#include "ui.h"
+#include "tour.h"
+#include "frame_png.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define W 240
+#define H 320
+#define FRAME_MS 33   /* ~30 fps */
+
+/* XRGB8888 framebuffer that LVGL renders straight into. */
+static uint8_t fb[W * H * 4];
+static uint8_t rgb[W * H * 3];
+
+static void flush_cb(lv_display_t *disp, const lv_area_t *area, uint8_t *px_map)
+{
+    (void)area;
+    (void)px_map; /* full-refresh mode renders into fb directly */
+    lv_display_flush_ready(disp);
+}
+
+int main(int argc, char **argv)
+{
+    const char *outdir = (argc > 1) ? argv[1] : "frames";
+
+    lv_init();
+
+    lv_display_t *disp = lv_display_create(W, H);
+    lv_display_set_color_format(disp, LV_COLOR_FORMAT_XRGB8888);
+    lv_display_set_buffers(disp, fb, NULL, sizeof(fb), LV_DISPLAY_RENDER_MODE_FULL);
+    lv_display_set_flush_cb(disp, flush_cb);
+
+    ui_init();
+
+    int nev;
+    const tour_event_t *ev = tour_events(&nev);
+    int total = tour_total_frames();
+    int ei = 0;
+
+    char path[1024];
+    for (int frame = 0; frame < total; frame++) {
+        /* fire any scripted inputs due this frame */
+        while (ei < nev && ev[ei].frame == frame) {
+            ui_send_key(ev[ei].key);
+            ei++;
+        }
+
+        lv_tick_inc(FRAME_MS);
+        lv_timer_handler();
+
+        /* XRGB8888 in memory is B,G,R,X (little-endian) -> pack to R,G,B */
+        for (int i = 0; i < W * H; i++) {
+            rgb[i * 3 + 0] = fb[i * 4 + 2];
+            rgb[i * 3 + 1] = fb[i * 4 + 1];
+            rgb[i * 3 + 2] = fb[i * 4 + 0];
+        }
+
+        snprintf(path, sizeof(path), "%s/frame_%04d.png", outdir, frame);
+        if (frame_png_write(path, rgb, W, H) != 0) {
+            fprintf(stderr, "failed to write %s\n", path);
+            return 1;
+        }
+    }
+
+    printf("wrote %d frames (%dx%d) to %s\n", total, W, H, outdir);
+    return 0;
+}

--- a/sim/tour.c
+++ b/sim/tour.c
@@ -1,0 +1,36 @@
+#include "tour.h"
+
+/*
+ * At ~30 fps (33 ms/frame) this is a ~7 second loop:
+ *   - scroll down the main menu
+ *   - open Music
+ *   - scroll the song list
+ *   - play a track and watch Now Playing progress
+ *   - back out to the menu
+ */
+static const tour_event_t EVENTS[] = {
+    {  15, UI_KEY_NEXT   },  /* Music -> Photos */
+    {  25, UI_KEY_NEXT   },  /* -> Videos */
+    {  35, UI_KEY_NEXT   },  /* -> Extras */
+    {  45, UI_KEY_PREV   },  /* back up ... */
+    {  55, UI_KEY_PREV   },
+    {  65, UI_KEY_PREV   },  /* back to Music */
+    {  78, UI_KEY_SELECT },  /* open Songs */
+    {  92, UI_KEY_NEXT   },
+    { 102, UI_KEY_NEXT   },
+    { 112, UI_KEY_NEXT   },  /* land on "Reptilia" */
+    { 128, UI_KEY_SELECT },  /* play -> Now Playing */
+    { 250, UI_KEY_MENU   },  /* back to Songs */
+    { 265, UI_KEY_MENU   },  /* back to Menu (via songs' MENU handler is Menu) */
+};
+
+const tour_event_t *tour_events(int *count)
+{
+    *count = (int)(sizeof(EVENTS) / sizeof(EVENTS[0]));
+    return EVENTS;
+}
+
+int tour_total_frames(void)
+{
+    return 285;
+}

--- a/sim/tour.h
+++ b/sim/tour.h
@@ -1,0 +1,24 @@
+/*
+ * tour.h — The scripted "demo tour" of the UI.
+ *
+ * The tour is plain data: a list of (frame, key) events. The capture harness
+ * plays it back at a fixed timestep so the recorded animation is byte-for-byte
+ * reproducible on any machine, regardless of CI load. To change what the demo
+ * shows, edit the table in tour.c — no capture code changes needed.
+ */
+#ifndef TOUR_H
+#define TOUR_H
+
+#include "ui.h"
+
+typedef struct {
+    int      frame;  /* frame index at which to fire this input */
+    ui_key_t key;
+} tour_event_t;
+
+/* Returns the event table and its length, plus the total frame count to
+ * render (enough to let the final animation settle). */
+const tour_event_t *tour_events(int *count);
+int tour_total_frames(void);
+
+#endif /* TOUR_H */

--- a/ui/ui.c
+++ b/ui/ui.c
@@ -1,0 +1,319 @@
+/*
+ * ui.c — A small but real iPod-classic-style UI on LVGL v9.
+ *
+ * Screens: a root Menu, a Songs list, and a Now Playing view. Selection moves
+ * with a smooth animated highlight (the classic blue bar), and Now Playing
+ * animates a progress bar so the recorded demo actually shows motion.
+ *
+ * Everything here is portable LVGL — no hardware headers — so the device
+ * firmware and the CI simulator share this exact file.
+ */
+#include "ui.h"
+#include "lvgl.h"
+
+#include <stdio.h>
+
+/* iPod 5G portrait menu geometry. */
+#define UI_W 240
+#define UI_H 320
+#define STATUSBAR_H 26
+#define ROW_H 34
+
+/* ---- iPod-ish palette ---------------------------------------------------- */
+#define COL_BG        lv_color_hex(0xffffff)
+#define COL_TEXT      lv_color_hex(0x101010)
+#define COL_SEL_TOP   lv_color_hex(0x4a90ff)
+#define COL_SEL_BOT   lv_color_hex(0x1560d8)
+#define COL_SEL_TEXT  lv_color_hex(0xffffff)
+#define COL_BAR_TOP   lv_color_hex(0xdfe4ea)
+#define COL_BAR_BOT   lv_color_hex(0xb6bec9)
+#define COL_ACCENT    lv_color_hex(0x1560d8)
+
+typedef enum { SCREEN_MENU, SCREEN_SONGS, SCREEN_NOWPLAYING } screen_id_t;
+
+/* A simple list-style screen (Menu and Songs both use this shape). */
+typedef struct {
+    lv_obj_t   *screen;
+    lv_obj_t   *list;       /* scrollable container of rows */
+    lv_obj_t   *highlight;  /* the animated selection bar   */
+    lv_obj_t  **rows;
+    const char *const *items;
+    int         count;
+    int         sel;
+} list_view_t;
+
+static struct {
+    screen_id_t   current;
+    list_view_t   menu;
+    list_view_t   songs;
+
+    /* Now Playing */
+    lv_obj_t     *np_screen;
+    lv_obj_t     *np_bar;
+    lv_obj_t     *np_elapsed;
+    lv_obj_t     *np_remain;
+} S;
+
+static const char *const MENU_ITEMS[] = {
+    "Music", "Photos", "Videos", "Extras", "Settings", "Shuffle Songs",
+};
+static const char *const SONG_ITEMS[] = {
+    "Baba O'Riley", "1979", "Such Great Heights", "Reptilia",
+    "Karma Police", "Time to Pretend", "Electioneering",
+};
+
+/* ---- shared styling ------------------------------------------------------ */
+
+static void make_statusbar(lv_obj_t *screen, const char *title)
+{
+    lv_obj_t *bar = lv_obj_create(screen);
+    lv_obj_remove_style_all(bar);
+    lv_obj_set_size(bar, UI_W, STATUSBAR_H);
+    lv_obj_set_pos(bar, 0, 0);
+    lv_obj_set_style_bg_opa(bar, LV_OPA_COVER, 0);
+    lv_obj_set_style_bg_color(bar, COL_BAR_TOP, 0);
+    lv_obj_set_style_bg_grad_color(bar, COL_BAR_BOT, 0);
+    lv_obj_set_style_bg_grad_dir(bar, LV_GRAD_DIR_VER, 0);
+    lv_obj_set_style_border_width(bar, 0, 0);
+    lv_obj_set_style_border_side(bar, LV_BORDER_SIDE_BOTTOM, 0);
+    lv_obj_set_style_border_width(bar, 1, 0);
+    lv_obj_set_style_border_color(bar, lv_color_hex(0x8a94a0), 0);
+
+    lv_obj_t *label = lv_label_create(bar);
+    lv_label_set_text(label, title);
+    lv_obj_set_style_text_font(label, &lv_font_montserrat_16, 0);
+    lv_obj_set_style_text_color(label, COL_TEXT, 0);
+    lv_obj_center(label);
+
+    /* A tiny battery glyph on the right, purely cosmetic. */
+    lv_obj_t *batt = lv_label_create(bar);
+    lv_label_set_text(batt, LV_SYMBOL_BATTERY_FULL);
+    lv_obj_set_style_text_color(batt, COL_TEXT, 0);
+    lv_obj_align(batt, LV_ALIGN_RIGHT_MID, -8, 0);
+}
+
+/* Move the highlight bar to the selected row with a smooth animation and keep
+ * the row visible. Also recolours row text for the selected/deselected rows. */
+static void anim_y_cb(void *obj, int32_t v) { lv_obj_set_y((lv_obj_t *)obj, v); }
+
+static void list_apply_selection(list_view_t *lv, int new_sel)
+{
+    if (new_sel < 0) new_sel = 0;
+    if (new_sel >= lv->count) new_sel = lv->count - 1;
+
+    /* de-tint old row, tint new row */
+    lv_obj_set_style_text_color(lv->rows[lv->sel], COL_TEXT, 0);
+    lv_obj_set_style_text_color(lv->rows[new_sel], COL_SEL_TEXT, 0);
+    lv->sel = new_sel;
+
+    int target_y = new_sel * ROW_H;
+
+    lv_anim_t a;
+    lv_anim_init(&a);
+    lv_anim_set_var(&a, lv->highlight);
+    lv_anim_set_values(&a, lv_obj_get_y(lv->highlight), target_y);
+    lv_anim_set_time(&a, 140);
+    lv_anim_set_path_cb(&a, lv_anim_path_ease_out);
+    lv_anim_set_exec_cb(&a, anim_y_cb);
+    lv_anim_start(&a);
+
+    lv_obj_scroll_to_view(lv->rows[new_sel], LV_ANIM_ON);
+}
+
+static void build_list_view(list_view_t *lv, const char *title,
+                            const char *const *items, int count,
+                            bool chevron)
+{
+    lv->items = items;
+    lv->count = count;
+    lv->sel   = 0;
+
+    lv->screen = lv_obj_create(NULL);
+    lv_obj_remove_style_all(lv->screen);
+    lv_obj_set_style_bg_opa(lv->screen, LV_OPA_COVER, 0);
+    lv_obj_set_style_bg_color(lv->screen, COL_BG, 0);
+
+    make_statusbar(lv->screen, title);
+
+    lv->list = lv_obj_create(lv->screen);
+    lv_obj_remove_style_all(lv->list);
+    lv_obj_set_size(lv->list, UI_W, UI_H - STATUSBAR_H);
+    lv_obj_set_pos(lv->list, 0, STATUSBAR_H);
+    lv_obj_set_style_bg_opa(lv->list, LV_OPA_TRANSP, 0);
+    lv_obj_set_scrollbar_mode(lv->list, LV_SCROLLBAR_MODE_OFF);
+    lv_obj_set_scroll_dir(lv->list, LV_DIR_VER);
+
+    /* selection highlight sits behind the row labels */
+    lv->highlight = lv_obj_create(lv->list);
+    lv_obj_remove_style_all(lv->highlight);
+    lv_obj_set_size(lv->highlight, UI_W, ROW_H);
+    lv_obj_set_pos(lv->highlight, 0, 0);
+    lv_obj_set_style_bg_opa(lv->highlight, LV_OPA_COVER, 0);
+    lv_obj_set_style_bg_color(lv->highlight, COL_SEL_TOP, 0);
+    lv_obj_set_style_bg_grad_color(lv->highlight, COL_SEL_BOT, 0);
+    lv_obj_set_style_bg_grad_dir(lv->highlight, LV_GRAD_DIR_VER, 0);
+
+    lv->rows = lv_malloc(sizeof(lv_obj_t *) * count);
+    for (int i = 0; i < count; i++) {
+        lv_obj_t *row = lv_obj_create(lv->list);
+        lv_obj_remove_style_all(row);
+        lv_obj_set_size(row, UI_W, ROW_H);
+        lv_obj_set_pos(row, 0, i * ROW_H);
+        lv_obj_set_style_bg_opa(row, LV_OPA_TRANSP, 0);
+        lv_obj_set_style_border_side(row, LV_BORDER_SIDE_BOTTOM, 0);
+        lv_obj_set_style_border_width(row, 1, 0);
+        lv_obj_set_style_border_color(row, lv_color_hex(0xe2e2e2), 0);
+
+        lv_obj_t *label = lv_label_create(row);
+        lv_label_set_text(label, items[i]);
+        lv_obj_set_style_text_font(label, &lv_font_montserrat_16, 0);
+        lv_obj_set_style_text_color(label, i == 0 ? COL_SEL_TEXT : COL_TEXT, 0);
+        lv_obj_align(label, LV_ALIGN_LEFT_MID, 12, 0);
+        lv->rows[i] = label;
+
+        if (chevron) {
+            lv_obj_t *chev = lv_label_create(row);
+            lv_label_set_text(chev, LV_SYMBOL_RIGHT);
+            lv_obj_set_style_text_color(chev, lv_color_hex(0x9aa2ac), 0);
+            lv_obj_align(chev, LV_ALIGN_RIGHT_MID, -10, 0);
+        }
+    }
+}
+
+/* ---- Now Playing --------------------------------------------------------- */
+
+static void build_now_playing(void)
+{
+    S.np_screen = lv_obj_create(NULL);
+    lv_obj_remove_style_all(S.np_screen);
+    lv_obj_set_style_bg_opa(S.np_screen, LV_OPA_COVER, 0);
+    lv_obj_set_style_bg_color(S.np_screen, COL_BG, 0);
+
+    make_statusbar(S.np_screen, "Now Playing");
+
+    /* album-art placeholder */
+    lv_obj_t *art = lv_obj_create(S.np_screen);
+    lv_obj_remove_style_all(art);
+    lv_obj_set_size(art, 150, 150);
+    lv_obj_align(art, LV_ALIGN_TOP_MID, 0, STATUSBAR_H + 16);
+    lv_obj_set_style_radius(art, 6, 0);
+    lv_obj_set_style_bg_opa(art, LV_OPA_COVER, 0);
+    lv_obj_set_style_bg_color(art, lv_color_hex(0x2b2f36), 0);
+    lv_obj_set_style_bg_grad_color(art, lv_color_hex(0x0d0f12), 0);
+    lv_obj_set_style_bg_grad_dir(art, LV_GRAD_DIR_VER, 0);
+    lv_obj_t *note = lv_label_create(art);
+    lv_label_set_text(note, LV_SYMBOL_AUDIO);
+    lv_obj_set_style_text_color(note, lv_color_hex(0x9aa2ac), 0);
+    lv_obj_set_style_text_font(note, &lv_font_montserrat_22, 0);
+    lv_obj_center(note);
+
+    lv_obj_t *title = lv_label_create(S.np_screen);
+    lv_label_set_text(title, "Such Great Heights");
+    lv_obj_set_style_text_font(title, &lv_font_montserrat_16, 0);
+    lv_obj_set_style_text_color(title, COL_TEXT, 0);
+    lv_obj_align(title, LV_ALIGN_TOP_MID, 0, STATUSBAR_H + 178);
+
+    lv_obj_t *artist = lv_label_create(S.np_screen);
+    lv_label_set_text(artist, "The Postal Service");
+    lv_obj_set_style_text_font(artist, &lv_font_montserrat_14, 0);
+    lv_obj_set_style_text_color(artist, lv_color_hex(0x6b727b), 0);
+    lv_obj_align(artist, LV_ALIGN_TOP_MID, 0, STATUSBAR_H + 200);
+
+    S.np_bar = lv_bar_create(S.np_screen);
+    lv_obj_set_size(S.np_bar, UI_W - 40, 6);
+    lv_obj_align(S.np_bar, LV_ALIGN_TOP_MID, 0, STATUSBAR_H + 236);
+    lv_obj_set_style_bg_color(S.np_bar, COL_BAR_BOT, 0);
+    lv_obj_set_style_bg_color(S.np_bar, COL_ACCENT, LV_PART_INDICATOR);
+    lv_obj_set_style_radius(S.np_bar, 3, 0);
+    lv_obj_set_style_radius(S.np_bar, 3, LV_PART_INDICATOR);
+    lv_bar_set_range(S.np_bar, 0, 1000);
+    lv_bar_set_value(S.np_bar, 0, LV_ANIM_OFF);
+
+    S.np_elapsed = lv_label_create(S.np_screen);
+    lv_label_set_text(S.np_elapsed, "0:00");
+    lv_obj_set_style_text_font(S.np_elapsed, &lv_font_montserrat_14, 0);
+    lv_obj_set_style_text_color(S.np_elapsed, lv_color_hex(0x6b727b), 0);
+    lv_obj_align(S.np_elapsed, LV_ALIGN_TOP_LEFT, 20, STATUSBAR_H + 246);
+
+    S.np_remain = lv_label_create(S.np_screen);
+    lv_label_set_text(S.np_remain, "-3:24");
+    lv_obj_set_style_text_font(S.np_remain, &lv_font_montserrat_14, 0);
+    lv_obj_set_style_text_color(S.np_remain, lv_color_hex(0x6b727b), 0);
+    lv_obj_align(S.np_remain, LV_ALIGN_TOP_RIGHT, -20, STATUSBAR_H + 246);
+}
+
+/* Track length in seconds for the fake progress readout. */
+#define NP_TRACK_SECONDS 204
+
+static void np_progress_cb(void *var, int32_t v)
+{
+    (void)var;
+    lv_bar_set_value(S.np_bar, v, LV_ANIM_OFF);
+
+    int elapsed = (int)((int64_t)v * NP_TRACK_SECONDS / 1000);
+    int remain  = NP_TRACK_SECONDS - elapsed;
+    char buf[16];
+    snprintf(buf, sizeof(buf), "%d:%02d", elapsed / 60, elapsed % 60);
+    lv_label_set_text(S.np_elapsed, buf);
+    snprintf(buf, sizeof(buf), "-%d:%02d", remain / 60, remain % 60);
+    lv_label_set_text(S.np_remain, buf);
+}
+
+static void now_playing_start_anim(void)
+{
+    lv_anim_t a;
+    lv_anim_init(&a);
+    lv_anim_set_var(&a, S.np_bar);
+    lv_anim_set_values(&a, 0, 1000);
+    lv_anim_set_time(&a, 6000);
+    lv_anim_set_exec_cb(&a, np_progress_cb);
+    lv_anim_start(&a);
+}
+
+/* ---- navigation ---------------------------------------------------------- */
+
+static void show_screen(screen_id_t id)
+{
+    S.current = id;
+    switch (id) {
+        case SCREEN_MENU:        lv_screen_load(S.menu.screen);  break;
+        case SCREEN_SONGS:       lv_screen_load(S.songs.screen); break;
+        case SCREEN_NOWPLAYING:
+            lv_screen_load(S.np_screen);
+            now_playing_start_anim();
+            break;
+    }
+}
+
+void ui_send_key(ui_key_t key)
+{
+    switch (S.current) {
+        case SCREEN_MENU:
+            if (key == UI_KEY_NEXT) list_apply_selection(&S.menu, S.menu.sel + 1);
+            else if (key == UI_KEY_PREV) list_apply_selection(&S.menu, S.menu.sel - 1);
+            else if (key == UI_KEY_SELECT) {
+                if (S.menu.sel == 0) show_screen(SCREEN_SONGS);       /* Music */
+                else show_screen(SCREEN_NOWPLAYING);                  /* stub  */
+            }
+            break;
+
+        case SCREEN_SONGS:
+            if (key == UI_KEY_NEXT) list_apply_selection(&S.songs, S.songs.sel + 1);
+            else if (key == UI_KEY_PREV) list_apply_selection(&S.songs, S.songs.sel - 1);
+            else if (key == UI_KEY_SELECT) show_screen(SCREEN_NOWPLAYING);
+            else if (key == UI_KEY_MENU) show_screen(SCREEN_MENU);
+            break;
+
+        case SCREEN_NOWPLAYING:
+            if (key == UI_KEY_MENU) show_screen(SCREEN_SONGS);
+            break;
+    }
+}
+
+void ui_init(void)
+{
+    build_list_view(&S.menu,  "iPod",  MENU_ITEMS, (int)(sizeof(MENU_ITEMS) / sizeof(MENU_ITEMS[0])), true);
+    build_list_view(&S.songs, "Songs", SONG_ITEMS, (int)(sizeof(SONG_ITEMS) / sizeof(SONG_ITEMS[0])), false);
+    build_now_playing();
+    show_screen(SCREEN_MENU);
+}

--- a/ui/ui.h
+++ b/ui/ui.h
@@ -1,0 +1,39 @@
+/*
+ * ui.h — Hardware-independent iPod-style UI built on LVGL.
+ *
+ * This layer knows nothing about the ESP32, the clickwheel, I2S, or the SD
+ * card. It draws into whatever LVGL display is active and receives input
+ * through ui_send_key(). On the device, the clickwheel driver calls
+ * ui_send_key(); in the simulator, the scripted tour calls the same function.
+ * Keeping this seam clean is what lets the exact same UI code run on-device
+ * and in headless CI.
+ */
+#ifndef UI_H
+#define UI_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Logical input events. The clickwheel maps rotation + center button to
+ * these; the simulator tour emits them directly. */
+typedef enum {
+    UI_KEY_PREV,   /* wheel counter-clockwise: move selection up   */
+    UI_KEY_NEXT,   /* wheel clockwise:         move selection down */
+    UI_KEY_SELECT, /* center button:           drill in / play     */
+    UI_KEY_MENU,   /* menu button:             go back             */
+} ui_key_t;
+
+/* Build the UI and show the root menu. Call once after LVGL is initialised
+ * and a display exists. */
+void ui_init(void);
+
+/* Feed one logical input event to the UI. Safe to call between
+ * lv_timer_handler() ticks. */
+void ui_send_key(ui_key_t key);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* UI_H */


### PR DESCRIPTION
## Summary

Adds a **headless LVGL UI simulator** that renders the interface without any hardware, plus a CI pipeline that captures a scripted "tour" of the UI into an animated demo and auto-publishes it to the README on every merge to `main`. Also includes a written plan for the future **Phase 2 WASM live interactive demo**.

The core architectural decision: the UI (`ui/`) is kept strictly hardware-independent so the **same code runs on the ESP32, in the headless simulator, and (later) in the browser** — with a single input seam, `ui_send_key()`, that the clickwheel driver and the simulator tour both call.

## What's included

**`ui/` — shared, hardware-independent LVGL UI**
- Menu → Songs → Now Playing, with an animated selection highlight and an animated Now Playing progress bar.
- No hardware headers; the clickwheel maps to four logical inputs (`PREV`, `NEXT`, `SELECT`, `MENU`).

**`sim/` — headless capture harness**
- Renders LVGL into an in-memory framebuffer (no SDL, no X server, no GPU) and writes one PNG per frame.
- Drives LVGL's clock at a **fixed timestep**, so the captured animation is byte-identical across machines and never drops frames under CI load.
- `frame_png.c`: a tiny dependency-free PNG writer (no libpng/zlib/stb).
- `tour.c`: the demo as editable `{frame, key}` data.
- `encode.sh`: frames → animated WebP + GIF via ffmpeg.

**`.github/workflows/ui-demo.yml`**
- On PRs: builds, encodes, and uploads a preview artifact (also a build gate).
- On merge to `main`: publishes the animation to an orphan `media` branch that the README embeds by raw URL — keeping `main`'s history free of regenerated binaries.

**`docs/phase2-wasm-live-demo-plan.md`**
- Implementation plan for compiling the same `ui/` code to WebAssembly (Emscripten + LVGL SDL backend → HTML5 canvas) hosted on GitHub Pages, with an on-screen clickwheel. Architecture, build/hosting/CI, milestones, risks, and open decisions.

## Validation performed

Built and run in a Linux environment before submitting:
- Builds against **LVGL v9.2.2** (fetched via CMake FetchContent) — compiles clean.
- Harness produces **285 valid 240×320 PNG frames**; Menu and Now Playing screens render correctly.
- Output verified **byte-identical across two runs** (determinism).
- Frames assemble into a ~250 KB animated WebP.

## Notes for merging

- The README's embedded animation 404s until this lands on `main` and the workflow runs once to create the `media` branch. The workflow creates that branch automatically — no manual setup.
- `ffmpeg` is installed explicitly by the workflow, so it doesn't depend on the runner image.
- Phase 2 (WASM live demo) is **plan-only** in this PR — no implementation yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QdZEjNqQjRZiR2jHLtUpJa)_